### PR TITLE
Initial Release of Private Terraform Registry Module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,37 +1,26 @@
-# Local .terraform directories
-**/.terraform/*
-
-# .tfstate files
+# Terraform files
 *.tfstate
 *.tfstate.*
-
-# Crash log files
 crash.log
-crash.*.log
-
-# Exclude all .tfvars files, which are likely to contain sensitive data, such as
-# password, private keys, and other secrets. These should not be part of version 
-# control as they are data points which are potentially sensitive and subject 
-# to change depending on the environment.
 *.tfvars
 *.tfvars.json
-
-# Ignore override files as they are usually used to override resources locally and so
-# are not checked in
 override.tf
 override.tf.json
 *_override.tf
 *_override.tf.json
 
-# Ignore transient lock info files created by terraform apply
-.terraform.tfstate.lock.info
+# Terraform directories
+.terraform/
+.terraform.lock.hcl
 
-# Include override files you do wish to add to version control using negated pattern
-# !example_override.tf
+# Local .env files
+.env
+.env.*
 
-# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
-# example: *tfplan*
+# IDE files
+.vscode/
+.idea/
 
-# Ignore CLI configuration files
-.terraformrc
-terraform.rc
+# OS generated files
+.DS_Store
+Thumbs.db

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+#### Change Log
+
+[1.0.0] - 2024-12-24
+
+##### Added
+- Initial release of the Terraform AWS VPC-Subnets module.
+- Create VPC with specified CIDR block.
+- Create public and private subnets.
+- Enable/disable DNS hostnames and DNS support.
+- Configure Internet Gateways.
+- Configure Network ACLs.
+- Tag resources.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Subhamay Bhattacharyya
+Copyright (c) 2023 Subhamay Bhattacharyya
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,2 +1,134 @@
-# terraform-aws-vpc-subnets
-◉ Private Terraform Registry Module - Networking (VPC/Subnets/NACL/Route Tables/Internet Gateway)
+![](https://img.shields.io/github/commit-activity/t/subhamay-bhattacharyya/terraform-aws-vpc-subnets)&nbsp;![](https://img.shields.io/github/last-commit/subhamay-bhattacharyya/terraform-aws-vpc-subnets)&nbsp;![](https://img.shields.io/github/release-date/subhamay-bhattacharyya/terraform-aws-vpc-subnets)&nbsp;![](https://img.shields.io/github/repo-size/subhamay-bhattacharyya/terraform-aws-vpc-subnets)&nbsp;![](https://img.shields.io/github/directory-file-count/subhamay-bhattacharyya/terraform-aws-vpc-subnets)&nbsp;[](https://img.shields.io/github/issues/subhamay-bhattacharyya/terraform-aws-vpc-subnets)&nbsp;![](https://img.shields.io/github/languages/top/subhamay-bhattacharyya/terraform-aws-vpc-subnets)&nbsp;![](https://img.shields.io/github/commit-activity/m/subhamay-bhattacharyya/terraform-aws-vpc-subnets)&nbsp;![](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/bsubhamay/12772af0a4876ab905185d75933392fb/raw/terraform-aws-vpc-subnets.json?)
+
+# Terraform AWS VPC-Subnets Module
+
+This repository contains a Terraform module for creating and managing AWS VPC networks, including subnets, Internet Gateways, Network ACLs, and NAT Gateways.
+
+## Usage
+
+* Terraform module to create VPC subnets.
+* Module source: app.terraform.io/subhamay-bhattacharyya/vpc-subnets/aws
+* Version: 1.0.0
+
+### Required Inputs:
+- `aws-region`: The AWS region where the VPC and subnets will be created (e.g., "us-east-1").
+- `project-name`: The name of the project.
+- `environment-name`: The environment name (e.g., "devl").
+- `vpc-cidr`: The CIDR block for the VPC (e.g., "10.0.0.0/16").
+- `enable-dns-hostnames`: Boolean to enable/disable DNS hostnames in the VPC.
+- `enable-dns-support`: Boolean to enable/disable DNS support in the VPC.
+- `subnet-configuration`: A map defining the CIDR blocks for public and private subnets.
+- `ci-build`: A string representing the CI build identifier.
+
+### Example Usage:
+
+```hcl
+module "vpc_subnets" {
+  source  = "app.terraform.io/subhamay-bhattacharyya/vpc-subnets/aws"
+  version = "1.0.1"
+
+  aws-region               = "us-east-1"
+  project-name             = "your-project-name"
+  environment-name         = "devl"
+  vpc-cidr                 = "your-vpc-cidr-range"
+  subnet-configuration     = "your-subnet-configuration"
+  ci-build                 = "your-ci-build-string"
+}
+```
+
+### Subnet configuration
+
+#### Configure the numbers of public and private subnets using the variables
+
+```hcl
+public-subnet-count  = 1
+private-subnet-count = 1
+```
+
+Use local variables to configure the subnet CIDR blocks
+
+```hcl
+locals {
+  public-cidrs  = var.public-subnet-count > 0 ? [for i in range(0, var.public-subnet-count + 1, 2) : cidrsubnet(var.vpc-cidr, 8, i)] : []
+  private-cidrs = var.private-subnet-count > 0 ? [for i in range(1, var.private-subnet-count + 2, 2) : cidrsubnet(var.vpc-cidr, 8, i)] : []
+}
+
+locals {
+  subnet-configuration = {
+    public  = local.public-cidrs
+    private = local.private-cidrs
+  }
+}
+```
+
+##### DNS hostname and DNS support
+
+DNS hostname and DNS support are enabled by default. To override the default values, use false in the .tfvars file
+
+
+##### Default tags
+
+Use local variables to configure the default tags.
+_The default resource tags are implemented using the CI/CD Pipeline. The following mao just refers to it._
+```hcl
+locals {
+  tags = {
+    Environment      = var.environment-name
+    ProjectName      = var.project-name
+    GitHubRepository = var.github-repo
+    GitHubRef        = var.github-ref
+    GitHubURL        = var.github-url
+    GitHubSHA        = var.github-sha
+  }
+}
+```
+#### Note
+
+- To create only public subnets only pass `private-subnet-count=0`
+- To create only private subnets only pass `public-subnet-count=0`
+- Internet gateway will be created only for public subnets
+
+
+
+## Inputs
+
+| Name| Description| Type|Default|Required |
+|--- |--- |--- |--- |--- |
+| aws-region            | The AWS region where the VPC and subnets will be created                    | string | us-east-1 | yes      |
+| project-name          | The name of the project                                                     | string | n/a     | yes      |
+| environment-name      | The environment name (e.g., "devl")                                         | string | devl    | yes      |
+| vpc-cidr              | The CIDR block for the VPC                                                  | string | 10.0.0.0/16 | yes      |
+| enable-dns-hostnames  | Boolean to enable/disable DNS hostnames in the VPC                          | bool   | true    | no       |
+| enable-dns-support    | Boolean to enable/disable DNS support in the VPC                            | bool   | true    | no       |
+| subnet-configuration  | A map defining the CIDR blocks for public and private subnets               | map    | n/a     | yes      |
+| public-subnet-count   | The number of public subnets to create                                      | number | 1       | no       |
+| private-subnet-count  | The number of private subnets to create                                     | number | 1       | no       |
+| ci-build              | A string representing the CI build identifier                               | string | ""    | yes      |
+
+
+##### Subnet Configuration Input (Map)
+
+|Name|Description|Type|Default|Required|
+|--- |--- |--- |--- |--- |
+public-subnet-count|The number of public subnets to create|number|1|yes|
+private-subnet-count|The number of private subnets to create|number|1|yes|
+public-cidr|The CIDR blocks for the public subnets|list|n/a|yes|
+private-cidrs|The CIDR blocks for the private subnets|list|n/a|yes|
+
+
+## Outputs
+
+
+| Name| Description|
+|--- |--- |
+|az-list | The list of availability zones in the region|
+|vpc-id| VPC Id|
+|subnet-configuration| Configuration for public and private subnets|
+|internet-gateway-id| The ID of the Internet Gateway|
+|public-subnet-ids| The IDs of the public subnets|
+|private-subnet-ids| The IDs of the private subnets|
+|public-route-table-ids | The IDs of the public route tables|
+|private-route-table-ids| The IDs of the private route tables|
+|network-acl-id| The ID of the Network ACL|
+|public-nacl-ids| The IDs of the public network ACL associations|
+|private-nacl-ids| The IDs of the private network ACL associations|

--- a/VERSION
+++ b/VERSION
@@ -1,0 +1,15 @@
+#### Version: 1.0.0
+Initial release of the Terraform AWS VPC-Subnets module.
+Version: 1.0.0
+Author: Subhamay Bhattacharyya
+Created: 24-Dec-2024
+Updated: 
+Description: This module creates and manages AWS VPC networks, including subnets, Internet Gateways, Network ACLs using Terraform.
+
+## Features
+- Create VPC with specified CIDR block
+- Create public and private subnets
+- Enable/disable DNS hostnames and DNS support
+- Configure Internet Gateways
+- Configure Network ACLs
+- Tag resources

--- a/data.tf
+++ b/data.tf
@@ -1,0 +1,20 @@
+/*
+####################################################################################################
+# Terraform Data Blocks Configuration
+#
+# Description: This module creates a VPC Network (VPC/Subnets/Internet Gateway/NACL/NatGateway)
+#              using Terraform.
+#
+# Author: Subhamay Bhattacharyya
+# Created: 18-Nov-2024 
+# Version: 1.0
+#
+####################################################################################################
+*/
+
+# AWS Region and Caller Identity
+data "aws_region" "current" {}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_availability_zones" "available" {}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,255 @@
+/*
+####################################################################################################
+# Terraform Module Configuration
+#
+# Description: This module creates a VPC Network (VPC/Subnets/Internet Gateway/NACL/NatGateway)
+#              using Terraform.
+#
+# Author: Subhamay Bhattacharyya
+# Created: 18-Nov-2024 
+# Version: 1.0
+#
+####################################################################################################
+*/
+
+# This resource creates a random shuffle of the available AWS availability zones.
+# The input is a list of availability zone names obtained from the data source `aws_availability_zones`.
+# The `result_count` specifies the number of availability zones to include in the shuffled result.
+# The shuffled list can be used to distribute resources across multiple availability zones for high availability.
+# --- Random Shuffle
+resource "random_shuffle" "az_list" {
+  input        = data.aws_availability_zones.available.names
+  result_count = max(length(var.subnet-configuration.public), length(var.subnet-configuration.private))
+}
+
+# Creates an AWS Virtual Private Cloud (VPC) with the specified CIDR block.
+# Enables DNS hostnames and DNS support within the VPC.
+# Tags the VPC with a name that includes the project name and CI build identifier.
+#
+# Arguments:
+#   - var.vpc_cidr: The CIDR block for the VPC.
+#   - var.project_name: The name of the project.
+#   - var.ci_build: The CI build identifier.
+resource "aws_vpc" "vpc" {
+  cidr_block           = var.vpc-cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = {
+    Name = "${var.project-name}-vpc${var.ci-build}"
+  }
+}
+
+# Creates a AWS Internet Gateway and attaches it to the specified VPC if public cidr is a non empty list.
+# 
+# Arguments:
+#   vpc_id - The ID of the VPC to attach the Internet Gateway to.
+# 
+# Tags:
+#   Name - A name tag for the Internet Gateway, which includes the project name and CI build identifier.
+resource "aws_internet_gateway" "igw" {
+  count  = length(var.subnet-configuration.public) > 0 ? 1 : 0
+  vpc_id = aws_vpc.vpc.id
+
+  tags = {
+    Name = "${var.project-name}-igw${var.ci-build}"
+  }
+}
+
+
+# Creates a public subnets in the specified VPC. The number of subnets created is determined by the length of the public CIDR list.
+# 
+# Arguments:
+# - count: The number of subnets to create, determined by the variable `var.max_subnet_count`.
+# - vpc_id: The ID of the VPC where the subnet will be created, obtained from the `aws_vpc.vpc` resource.
+# - cidr_block: The CIDR block for the subnet, specified by the `var.public_cidrs` variable.
+# - map_public_ip_on_launch: Boolean to indicate whether to assign a public IP address to instances launched in this subnet.
+# - availability_zone: The availability zone for the subnet, determined by the `random_shuffle.az_list` resource.
+# 
+# Tags:
+# - Name: A tag to name the subnet, which includes the availability zone index and an optional build identifier from `var.ci_build`.
+resource "aws_subnet" "public_subnet" {
+  count                   = length(var.subnet-configuration.public)
+  vpc_id                  = aws_vpc.vpc.id
+  cidr_block              = var.subnet-configuration.public[count.index]
+  map_public_ip_on_launch = true
+  availability_zone       = random_shuffle.az_list.result[count.index]
+
+  tags = {
+    Name = "public subnet az-${count.index + 1}${var.ci-build}"
+  }
+}
+
+# Creates a public route table for the specified VPC. This route table will be used to route traffic to the internet gateway.
+# 
+# Arguments:
+#   vpc_id: The ID of the VPC where the route table will be created.
+# 
+# Tags:
+#   Name: A name tag for the route table, which includes the project name and CI build identifier.
+resource "aws_route_table" "public_rt" {
+  count  = length(var.subnet-configuration.public)
+  vpc_id = aws_vpc.vpc.id
+
+  tags = {
+    Name = "${var.project-name}-public-rt-${count.index+1}${var.ci-build}"
+  }
+}
+
+# Associates the specified subnet with the specified route table.
+# This resource creates an association between a subnet and a route table.
+# 
+# Arguments:
+#   count          - The number of subnet associations to create, based on the maximum subnet count.
+#   subnet_id      - The ID of the subnet to associate with the route table.
+#   route_table_id - The ID of the route table to associate with the subnet.
+resource "aws_route_table_association" "public_sn_assoc" {
+  count          = length(var.subnet-configuration.public)
+  subnet_id      = aws_subnet.public_subnet[count.index].id
+  route_table_id = aws_route_table.public_rt[count.index].id
+}
+
+# Creates a route in the specified route table that directs traffic destined for
+# the specified CIDR block (0.0.0.0/0) to the internet gateway. This effectively
+# allows public internet access for resources associated with this route table.
+# 
+# Arguments:
+# - route_table_id: The ID of the route table where the route will be added.
+# - destination_cidr_block: The CIDR block that this route applies to.
+# - gateway_id: The ID of the internet gateway to which the traffic will be routed.
+resource "aws_route" "public_route" {
+  count                  = length(var.subnet-configuration.public)
+  route_table_id         = aws_route_table.public_rt[count.index].id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.igw[0].id
+}
+
+# Creates a private subnet within a specified VPC. The number of subnets created is determined by the length of the private CIDR list.
+# 
+# Arguments:
+#   count: The number of subnets to create, determined by the variable `var.max_subnet_count`.
+#   vpc_id: The ID of the VPC where the subnet will be created, obtained from the `aws_vpc.vpc.id`.
+#   cidr_block: The CIDR block for the subnet, specified by the variable `var.private_cidrs` at the index of the current count.
+#   map_public_ip_on_launch: Boolean value to specify whether instances launched in this subnet should be assigned a public IP address. Set to `false` for private subnets.
+#   availability_zone: The availability zone for the subnet, determined by the `random_shuffle.az_list.result` at the index of the current count.
+# 
+# Tags:
+#   Name: A tag to name the subnet, formatted as "private subnet az-{index + 1}{var.ci_build}".
+resource "aws_subnet" "private_subnet" {
+  count                   = length(var.subnet-configuration.private)
+  vpc_id                  = aws_vpc.vpc.id
+  cidr_block              = var.subnet-configuration.private[count.index]
+  map_public_ip_on_launch = false
+  availability_zone       = random_shuffle.az_list.result[count.index]
+
+
+  tags = {
+    Name = "private subnet az-${count.index + 1}${var.ci-build}"
+  }
+}
+
+# Creates a private route table for the specified VPC.
+# 
+# Arguments:
+#   vpc_id - The ID of the VPC where the route table will be created.
+# 
+# Tags:
+#   Name - A name tag for the route table, which includes the project name and CI build identifier.
+resource "aws_route_table" "private_rt" {
+  count  = length(var.subnet-configuration.private)
+  vpc_id = aws_vpc.vpc.id
+
+  tags = {
+    Name = "${var.project-name}-private-rt-${count.index+1}${var.ci-build}"
+  }
+}
+
+# Associates a private subnet with a route table.
+# 
+# Arguments:
+#   count          - The number of subnet associations to create, based on the variable `max_subnet_count`.
+#   subnet_id      - The ID of the private subnet to associate with the route table, retrieved from the list of private subnets.
+#   route_table_id - The ID of the private route table to associate with the subnet.
+resource "aws_route_table_association" "private_sn_assoc" {
+  count          = length(var.subnet-configuration.private) 
+  subnet_id      = aws_subnet.private_subnet[count.index].id
+  route_table_id = aws_route_table.private_rt[count.index].id
+}
+
+# Creates an AWS Network ACL (NACL) resource.
+# 
+# This resource defines a network ACL for the specified VPC.
+# 
+# Arguments:
+# - vpc_id: The ID of the VPC where the network ACL will be created.
+# 
+# Ingress Rules:
+# - protocol: The protocol number. `-1` means all protocols.
+# - rule_no: The rule number for the ingress rule.
+# - action: The action to take (allow or deny).
+# - cidr_block: The CIDR block to allow or deny traffic from.
+# - from_port: The starting port for the range.
+# - to_port: The ending port for the range.
+# 
+# Egress Rules:
+# - protocol: The protocol number. `-1` means all protocols.
+# - rule_no: The rule number for the egress rule.
+# - action: The action to take (allow or deny).
+# - cidr_block: The CIDR block to allow or deny traffic to.
+# - from_port: The starting port for the range.
+# - to_port: The ending port for the range.
+# 
+# Tags:
+# - Name: A name tag for the network ACL, which includes the project name and CI build identifier.
+resource "aws_network_acl" "nacl" {
+  vpc_id = aws_vpc.vpc.id
+
+  ingress {
+    protocol   = -1
+    rule_no    = 100
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 0
+    to_port    = 0
+  }
+
+  egress {
+    protocol   = -1
+    rule_no    = 100
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 0
+    to_port    = 0
+  }
+
+  tags = {
+    Name = "${var.project-name} subnet nacl${var.ci-build}"
+  }
+}
+
+# Associates a network ACL with public subnets.
+# 
+# Arguments:
+#   count          - The number of subnet associations to create, based on the variable `max_subnet_count`.
+#   network_acl_id - The ID of the network ACL to associate with the subnets.
+#   subnet_id      - The ID of the public subnet to associate with the network ACL, indexed by the count.
+resource "aws_network_acl_association" "nacl_association_pub" {
+  count          = length(var.subnet-configuration.public)
+  network_acl_id = aws_network_acl.nacl.id
+  subnet_id      = aws_subnet.public_subnet[count.index].id
+}
+
+# Associates a network ACL with private subnets.
+# 
+# Arguments:
+#   count          - The number of subnet associations to create, based on the maximum subnet count.
+#   network_acl_id - The ID of the network ACL to associate with the subnets.
+#   subnet_id      - The ID of the private subnet to associate with the network ACL.
+#
+# Resources:
+#   aws_network_acl_association.nacl_association_pvt - Creates an association between the specified network ACL and private subnets.
+resource "aws_network_acl_association" "nacl_association_pvt" {
+  count          = length(var.subnet-configuration.private)
+  network_acl_id = aws_network_acl.nacl.id
+  subnet_id      = aws_subnet.private_subnet[count.index].id
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,100 @@
+/*
+####################################################################################################
+# Terraform AWS Networking Outputs Configuration
+#
+# Description: This module creates a VPC Network (VPC/Subnets/Internet Gateway/NACL/NatGateway)
+#              using Terraform.
+#
+# Author: Subhamay Bhattacharyya
+# Created: 18-Nov-2024 
+# Version: 1.0
+#
+####################################################################################################
+*/
+
+# This output provides the list of Availability Zones.
+# It retrieves the value from the random_shuffle resource named az_list.
+output "az-list" {
+  description = "The list of Availability Zones"
+  value       = random_shuffle.az_list
+}
+
+# This output block defines an output variable named "vpc-id".
+# It provides the ID of the VPC created by the aws_vpc resource.
+# The value attribute references the ID of the VPC from the aws_vpc resource.
+output "vpc-id" {
+  description = "The ID of the VPC"
+  value       = aws_vpc.vpc.id
+}
+
+
+# This output provides the configuration details for both public and private subnets.
+# The value is derived from the variable `subnet-configuration`.
+# It can be used to reference subnet settings in other modules or resources.
+output "subnet-configuration" {
+  description = "Configuration for public and private subnets"
+  value       = var.subnet-configuration
+}
+
+
+# This output variable provides the ID of the Internet Gateway created by the module.
+output "internet-gateway-id" {
+  description = "The ID of the Internet Gateway"
+  value       = try(aws_internet_gateway.igw[0].id, "no internet gateway")
+}
+
+
+# This output provides the IDs of the public subnets created by the module.
+output "public-subnet-ids" {
+  description = "The IDs of the public subnets"
+  value       = try(aws_subnet.public_subnet[*].id, "no public subnets")
+}
+
+# This output variable provides the IDs of the private subnets created by the module.
+# It is useful for referencing the private subnets in other parts of your Terraform configuration
+# or in other modules that depend on this networking module.
+output "private-subnet-ids" {
+  description = "The IDs of the private subnets"
+  value       = try(aws_subnet.private_subnet[*].id, "no private subnets")
+}
+
+# This output block defines an output variable named "public-route-table-id".
+# It provides the ID of the public route table created by the aws_route_table resource.
+# The description attribute gives a brief explanation of the output.
+# The value attribute references the ID of the first public route table in the aws_route_table.public_rt list.
+output "public-route-table-ids" {
+  description = "The IDs of the public route tables"
+  value       = try(aws_route_table.public_rt[*].id, "no public route table")
+}
+
+# This output variable provides the ID of the private route table.
+# It is useful for referencing the private route table in other modules or resources.
+# The value is obtained from the first element of the aws_route_table.private_rt array.
+output "private-route-table-ids" {
+  description = "The IDs of the private route tables"
+  value       = try(aws_route_table.private_rt[*].id, "no private route table")
+}
+
+# This output block defines an output variable named "network-acl-id".
+# It provides the ID of the Network ACL created by the aws_network_acl resource.
+# The description attribute gives a brief explanation of the output variable.
+# The value attribute assigns the ID of the Network ACL to the output variable.
+output "network-acl-id" {
+  description = "The ID of the Network ACL"
+  value       = aws_network_acl.nacl.id
+}
+
+# This output provides the IDs of the public network ACL associations.
+# It retrieves the IDs from the aws_network_acl_association resource
+# for the public network ACL associations.
+output "public-nacl-ids" {
+  description = "The IDs of the public network ACL associations"
+  value       = aws_network_acl_association.nacl_association_pub[*].id
+}
+
+# This output variable provides the IDs of the private network ACL associations.
+# It retrieves the IDs from the aws_network_acl_association resource for private subnets.
+output "private-nacl-ids" {
+  description = "The IDs of the private network ACL associations"
+  value       = aws_network_acl_association.nacl_association_pvt[*].id
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,88 @@
+/*
+####################################################################################################
+# Terraform AWS Networking Variables Configuration
+#
+# Description: This module creates a VPC Network (VPC/Subnets/Internet Gateway/NACL/NatGateway)
+#              using Terraform.
+#
+# Author: Subhamay Bhattacharyya
+# Created: 18-Nov-2024 
+# Version: 1.0
+#
+####################################################################################################
+*/
+
+######################################## AWS Configuration #########################################
+variable "aws-region" {
+  type    = string
+  default = "us-east-1"
+}
+
+######################################## Project Name ##############################################
+variable "project-name" {
+  description = "The name of the project"
+  type        = string
+  default     = "your-project-name"
+}
+
+######################################## Environment Name ##########################################
+variable "environment-name" {
+  type        = string
+  description = <<EOF
+  (Optional) The environment in which to deploy our resources to.
+
+  Options:
+  - devl : Development
+  - test: Test
+  - prod: Production
+
+  Default: devl
+  EOF
+  default     = "devl"
+
+  validation {
+    condition     = can(regex("^devl$|^test$|^prod$", var.environment-name))
+    error_message = "Err: environment is not valid."
+  }
+}
+
+######################################## Network Resources #########################################
+variable "vpc-cidr" {
+  description = "VPC CIDR range of IP addresses."
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+# -- Dns Hostnames
+variable "enable-dns-hostnames" {
+  description = "A boolean flag to enable/disable DNS hostnames in the VPC."
+  type        = bool
+  default     = true
+}
+
+# -- Dns Support
+variable "enable-dns-support" {
+  description = "A boolean flag to enable/disable DNS support in the VPC."
+  type        = bool
+  default     = true
+}
+
+
+variable "subnet-configuration" {
+  description = "Configuration for public and private subnets"
+  type = object({
+    public  = list(string)
+    private = list(string)
+  })
+  default = {
+    public  = []
+    private = []
+  }
+}
+######################################## GitHub ####################################################
+# The CI build string
+variable "ci-build" {
+  description = "The CI build string"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
### Initial Release of Terraform AWS VPC-Subnets Module

#### Description
This pull request introduces the initial release of the Terraform AWS VPC-Subnets module. It includes the following features:

- Creation of VPC with a specified CIDR block.
- Creation of public and private subnets.
- Enabling/disabling DNS hostnames and DNS support.
- Configuration of Internet Gateways.
- Configuration of Network ACLs.
- Tagging resources.

#### Key Changes
- **Added**: Initial setup and configuration of Terraform files.
- **Added**: `.gitignore` and `CHANGELOG.md` files.
- **Updated**: `LICENSE` and `README.md` files.
- **Created**: Main Terraform configuration files (`main.tf`, `variables.tf`, `outputs.tf`, `data.tf`).

#### Commits
- Initial setup and feature implementation.
- Documentation and license updates.

#### Potential Impacts
- None expected; this is a new module.

#### Follow-up Actions
- Review and merge the pull request.
- Update any relevant documentation or user guides.